### PR TITLE
JIRA Admins Should Be Able to Configure

### DIFF
--- a/src/main/java/com/smartbear/collaborator/BaseServlet.java
+++ b/src/main/java/com/smartbear/collaborator/BaseServlet.java
@@ -48,7 +48,7 @@ public class BaseServlet extends HttpServlet {
 	@Override
 	public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 		String username = userManager.getRemoteUsername(request);
-		if (username == null || !userManager.isSystemAdmin(username)) {
+		if (username == null || !userManager.isAdmin(username)) {
 			redirectToLogin(request, response);
 			return;
 		}


### PR DESCRIPTION
Previously only JIRA "system administrators" had the necessary permissions to be able to configure the SmartBear integration. Given this is a project-specific setting this should not require full "system administrator" privileges, but "jira administrator" privileges.